### PR TITLE
Define the way the md5sum is calculated

### DIFF
--- a/flac.md
+++ b/flac.md
@@ -191,7 +191,7 @@ Data     | Description
 
 FLAC specifies a minimum block size of 16 and a maximum block size of 65535, meaning the bit patterns corresponding to the numbers 0-15 in the minimum blocksize and maximum blocksize fields are invalid.
 
-The MD5 signature is made by performing an MD5 transformation on the samples of all channels interleaved, represented in a signed, little-endian form. This interleaving is on a per-sample basis, so for a stereo file this means first the first sample of the first channel, then the first sample of the second channel, then the second sample of the first channel etc. In case the bit depth is not a whole number of bytes, samples are left padded (right-justified) with zeros to a whole number of bytes before transforming.
+The MD5 signature is made by performing an MD5 transformation on the samples of all channels interleaved, represented in signed, little-endian form. This interleaving is on a per-sample basis, so for a stereo file this means first the first sample of the first channel, then the first sample of the second channel, then the second sample of the first channel etc. Before performing the MD5 transformation, all samples must be byte-aligned. So, in case the bit depth is not a whole number of bytes, additional zero bits are inserted at the most-significant position until each sample representation is a whole number of bytes.
 
 ## METADATA_BLOCK_PADDING
 Data     | Description


### PR DESCRIPTION
This should address issue #84 

Reference:
1. run `metaflac --list-md5sum somefile.flac`
2. run `flac -d --force-raw-format --endian=little --sign=signed somefile.flac -o somefile.raw`
3. run `md5sum somefile.raw`
4. Results should be identical