### PR TITLE
Split FORMAT in three subsections, add unsigned to signed ...

### DIFF
--- a/flac.md
+++ b/flac.md
@@ -114,7 +114,7 @@ All numbers used in a FLAC bitstream MUST be integers; there are no floating-poi
 
 All samples encoded to and decoded from the FLAC format MUST be in a signed representation.
 
-There are several ways to convert unsigned sample representations to signed sample representations, but the coding methods provided by the FLAC format work best on audio signals of which the numerical values of the samples are centered around zero, i.e. have no DC offset. In most unsigned audio formats, signals are centered around halfway the range of the unsigned integer type used. If that is the case, it is RECOMMENDED to convert all sample representations by first copying the number to a signed integer with sufficient range and then subtracting half of the range of the unsigned integer type, which should result in a signal with samples centered around 0.
+There are several ways to convert unsigned sample representations to signed sample representations, but the coding methods provided by the FLAC format work best on audio signals of which the numerical values of the samples are centered around zero, i.e. have no DC offset. In most unsigned audio formats, signals are centered around halfway the range of the unsigned integer type used. If that is the case, all sample representations SHOULD be converted by first copying the number to a signed integer with sufficient range and then subtracting half of the range of the unsigned integer type, which should result in a signal with samples centered around 0.
 
 ## Overview
 


### PR DESCRIPTION
The text under FORMAT is split in three subsections. I think
especially the format subset was easy to overlook. Also added
was some text about FLAC only handling signed samples,
conversion from unsigned to signed samples and an exception to
big-endian use in vorbis comments