### PR TITLE
Remove implementation-specific detail on max samplerate

### DIFF
--- a/flac.md
+++ b/flac.md
@@ -206,7 +206,7 @@ Data     | Description
 `u(16)`  | The maximum block size (in samples) used in the stream.
 `u(24)`  | The minimum frame size (in bytes) used in the stream. A value of `0` signifies that the value is not known.
 `u(24)`  | The maximum frame size (in bytes) used in the stream. A value of `0` signifies that the value is not known.
-`u(20)`  | Sample rate in Hz. Though 20 bits are available, the maximum sample rate is limited by the structure of frame headers to 655350 Hz. Also, a value of 0 is invalid.
+`u(20)`  | Sample rate in Hz. A value of 0 is invalid.
 `u(3)`   | (number of channels)-1. FLAC supports from 1 to 8 channels
 `u(5)`   | (bits per sample)-1. FLAC supports from 4 to 32 bits per sample. Currently the reference encoder and decoders only support up to 24 bits per sample.
 `u(36)`  | Total samples in stream. 'Samples' means inter-channel sample, i.e. one second of 44.1 kHz audio will have 44100 samples regardless of the number of channels. A value of zero here means the number of total samples is unknown.


### PR DESCRIPTION
This no longer applies to libFLAC, and it never applied to the FLAC format in general