### PR TITLE
Add 32 bps to bit depth table

### DIFF
--- a/flac.md
+++ b/flac.md
@@ -518,7 +518,7 @@ Value   | Bit depth
 0b100   | 16 bits per sample
 0b101   | 20 bits per sample
 0b110   | 24 bits per sample
-0b111   | reserved
+0b111   | 32 bits per sample
 
 The next bit is reserved and MUST be zero.
 


### PR DESCRIPTION
I was under the impression this was already in, but I just noticed it wasn't.