### PR TITLE
Consistency of block size, frame size, sample rate, bit depth

### DIFF
--- a/flac.md
+++ b/flac.md
@@ -35,7 +35,7 @@ FLAC owes much to the many people who have advanced the audio compression field 
 
 - **Subframe**: An encoded subblock. All subframes within a frame code for the same number of samples. A subframe MAY correspond to a subblock, else it corresponds to either the addition or subtraction of two subblocks, see [section on interchannel decorrelation](#interchannel-decorrelation).
 
-- **Blocksize**: The total number of samples contained in a block or coded in a frame, divided by the number of channels. In other words, the number of samples in any subblock of a block, or any subframe of a frame. This is also called **interchannel samples**.
+- **Block size**: The total number of samples contained in a block or coded in a frame, divided by the number of channels. In other words, the number of samples in any subblock of a block, or any subframe of a frame. This is also called **interchannel samples**.
 
 - **Bit depth** or **bits per sample**: the number of bits used to contain each sample. This MUST be the same for all subblocks in a block but MAY be different for different subframes in a frame because of [interchannel decorrelation](#interchannel-decorrelation).
 
@@ -69,7 +69,7 @@ In addition, FLAC specifies a metadata system (see [section on File-level metada
 
 The size used for blocking the audio data has a direct effect on the compression ratio. If the block size is too small, the resulting large number of frames mean that excess bits will be wasted on frame headers. If the block size is too large, the characteristics of the signal may vary so much that the encoder will be unable to find a good predictor. In order to simplify encoder/decoder design, FLAC imposes a minimum block size of 16 samples, and a maximum block size of 65535 samples. This range covers the optimal size for all of the audio data FLAC supports.
 
-While the block size MAY vary in a FLAC file, it is often difficult to find the optimal arrangement of block sizes for maximum compression. Because of this the FLAC format explicitly stores whether a file has a constant or a variable blocksize throughout the stream, and stores a block number instead of a sample number to slightly improve compression in case a stream has a constant block size.
+While the block size MAY vary in a FLAC file, it is often difficult to find the optimal arrangement of block sizes for maximum compression. Because of this the FLAC format explicitly stores whether a file has a constant or a variable block size throughout the stream, and stores a block number instead of a sample number to slightly improve compression in case a stream has a constant block size.
 
 Blocked data is passed to the predictor stage one subblock at a time. Each subblock is independently coded into a subframe, and the subframes are concatenated into a frame. Because each channel is coded separately, subframes MAY use different predictors, even within a frame.
 
@@ -157,7 +157,7 @@ A FLAC bitstream consists of the `fLaC` (i.e. 0x664C6143) marker at the beginnin
 
 FLAC supports up to 128 kinds of metadata blocks; currently 7 kinds are defined in the section [file-level metadata](#file-level-metadata).
 
-The audio data is composed of one or more audio frames. Each frame consists of a frame header, which contains a sync code, information about the frame like the block size, sample rate, number of channels, et cetera, and an 8-bit CRC. The frame header also contains either the sample number of the first sample in the frame (for variable-blocksize streams), or the frame number (for fixed-blocksize streams). This allows for fast, sample-accurate seeking to be performed. Following the frame header are encoded subframes, one for each channel. The frame is then zero-padded to a byte boundary and finished with a frame footer containing a checksum for the frame. Each subframe has its own header that specifies how the subframe is encoded.
+The audio data is composed of one or more audio frames. Each frame consists of a frame header, which contains a sync code, information about the frame like the block size, sample rate, number of channels, et cetera, and an 8-bit CRC. The frame header also contains either the sample number of the first sample in the frame (for variable block size streams), or the frame number (for fixed block size streams). This allows for fast, sample-accurate seeking to be performed. Following the frame header are encoded subframes, one for each channel. The frame is then zero-padded to a byte boundary and finished with a frame footer containing a checksum for the frame. Each subframe has its own header that specifies how the subframe is encoded.
 
 Since a decoder MAY start decoding in the middle of a stream, there MUST be a method to determine the start of a frame. A 15-bit sync code begins each frame. The sync code will not appear anywhere else in the frame header. However, since it MAY appear in the subframes, the decoder has two other ways of ensuring a correct sync. The first is to check that the rest of the frame header contains no invalid data. Even this is not foolproof since valid header patterns can still occur within the subframes. The decoder's final check is to generate an 8-bit CRC of the frame header and compare this to the CRC stored at the end of the frame header.
 
@@ -170,8 +170,8 @@ The FLAC format specifies a subset of itself as the Subset format. The purpose o
 
 - The [sample rate bits](#sample-rate-bits) in the frame header MUST be 0b0001-0b1110, i.e. the frame header MUST NOT refer to the streaminfo metadata block to find the sample rate.
 - The [bits depth bits](#bit-depth-bits) in the frame header MUST be 0b001-0b111, i.e. the frame header MUST NOT refer to the streaminfo metadata block to find the bit depth.
-- The stream MUST NOT contain blocks with more than 16384 inter-channel samples, i.e. the maximum blocksize must not be larger than 16384.
-- If the sample rate of the stream is less then or equal to 48000 Hz, the stream MUST NOT contain blocks with more than 4608 inter-channel samples, i.e. the maximum blocksize must not be larger than 4608.
+- The stream MUST NOT contain blocks with more than 16384 inter-channel samples, i.e. the maximum block size must not be larger than 16384.
+- If the sample rate of the stream is less then or equal to 48000 Hz, the stream MUST NOT contain blocks with more than 4608 inter-channel samples, i.e. the maximum block size must not be larger than 4608.
 - If the sample rate of the stream is less then or equal to 48000 Hz, the filter order in linear subframes (see section [linear predictor subframe](#linear-predictor-subframe)) MUST be less than or equal to 12, i.e. the subframe type bits in the subframe header (see [subframe header section](#subframe-header)) MUST NOT be 0b101100-0b111111.
 - The Rice partition order (see [coded residual section](#coded-residual)) MUST be less than or equal to 8.
 
@@ -214,7 +214,7 @@ Data     | Description
 `u(36)`  | Total samples in stream. 'Samples' means inter-channel sample, i.e. one second of 44.1 kHz audio will have 44100 samples regardless of the number of channels. A value of zero here means the number of total samples is unknown.
 `u(128)` | MD5 signature of the unencoded audio data. This allows the decoder to determine if an error exists in the audio data even when the error does not result in an invalid bitstream. A value of `0` signifies that the value is not known.
 
-The minimum block size is excluding the last block of a FLAC file, which may be smaller. If the minimum block size is equal to the maximum block size, the file contains a fixed block size stream. Note that in case of a stream with a variable blocksize, the actual maximum block size MAY be smaller than the maximum block size listed in the streaminfo block, and the actual smallest block size excluding the last block MAY be larger than the minimum block size listed in the streaminfo block. This is because the encoder has to write these fields before receiving any input audio data, and cannot know beforehand what block sizes it will use, only between what bounds these will be chosen.
+The minimum block size is excluding the last block of a FLAC file, which may be smaller. If the minimum block size is equal to the maximum block size, the file contains a fixed block size stream. Note that in case of a stream with a variable block size, the actual maximum block size MAY be smaller than the maximum block size listed in the streaminfo block, and the actual smallest block size excluding the last block MAY be larger than the minimum block size listed in the streaminfo block. This is because the encoder has to write these fields before receiving any input audio data, and cannot know beforehand what block sizes it will use, only between what bounds these will be chosen.
 
 FLAC specifies a minimum block size of 16 and a maximum block size of 65535, meaning the bit patterns corresponding to the numbers 0-15 in the minimum block size and maximum block size fields are invalid.
 
@@ -450,24 +450,24 @@ Directly after the last metadata block, one or more frames follow. Each frame co
 Each frame header stores the audio sample rate, number of bits per sample and number of channels independently of the streaminfo metadata block and other frame headers. This was done to permit multicasting of FLAC files but it also allows these properties to change mid-stream. Because not all environments in which FLAC decoders are used are able to cope with changes to these parameters during playback, a decoder MAY choose to stop decoding on such a change. A decoder that does not check for such a change could be vulnerable to buffer overflows. See also [the section on security considerations](#security-considerations).
 
 ## Frame header
-Each frame MUST start on a byte boundary and starts with the 15-bit frame sync code 0b111111111111100. Following the sync code is the blocking strategy bit, which MUST NOT change during the audio stream. The blocking strategy bit is 0 for a fixed blocksize stream or 1 for variable blocksize stream. If the blocking strategy is known, a decoder can include this bit when searching for the start of a frame to reduce the possibility of encountering a false positive, as the first two bytes of a frame are either 0xFFF8 for a fixed blocksize stream or 0xFFF9 for a variable blocksize stream.
+Each frame MUST start on a byte boundary and starts with the 15-bit frame sync code 0b111111111111100. Following the sync code is the blocking strategy bit, which MUST NOT change during the audio stream. The blocking strategy bit is 0 for a fixed block size stream or 1 for variable block size stream. If the blocking strategy is known, a decoder can include this bit when searching for the start of a frame to reduce the possibility of encountering a false positive, as the first two bytes of a frame are either 0xFFF8 for a fixed block size stream or 0xFFF9 for a variable block size stream.
 
-### Blocksize bits
+### Block size bits
 
-Following the frame sync code and blocksize strategy bit are 4 bits referred to as the blocksize bits. Their value relates to the blocksize according to the following table, where v is the value of the 4 bits as an unsigned number. In case the blocksize bits code for an uncommon blocksize, this is stored after the coded number, see [section uncommon blocksize](#uncommon-blocksize).
+Following the frame sync code and block size strategy bit are 4 bits referred to as the block size bits. Their value relates to the block size according to the following table, where v is the value of the 4 bits as an unsigned number. In case the block size bits code for an uncommon block size, this is stored after the coded number, see [section uncommon block size](#uncommon-block-size).
 
-Value           | Blocksize
+Value           | Block size
 :---------------|:-----------
 0b0000          | reserved
 0b0001          | 192
 0b0010 - 0b0101 | 144 \* (2\^v), i.e. 576, 1152, 2304 or 4608
-0b0110          | uncommon blocksize minus 1 stored as an 8-bit number
-0b0111          | uncommon blocksize minus 1 stored as a 16-bit number
+0b0110          | uncommon block size minus 1 stored as an 8-bit number
+0b0111          | uncommon block size minus 1 stored as a 16-bit number
 0b1000 - 0b1111 | 2\^v, i.e. 256, 512, 1024, 2048, 4096, 8192, 16384 or 32768
 
 ### Sample rate bits
 
-The next 4 bits, referred to as the sample rate bits, contain the sample rate of the audio according to the following table. In case the sample rate bits code for an uncommon sample rate, this is stored after the uncommon blocksize or after the coded number in case no uncommon blocksize was used. See [section uncommon sample rate](#uncommon-sample-rate).
+The next 4 bits, referred to as the sample rate bits, contain the sample rate of the audio according to the following table. In case the sample rate bits code for an uncommon sample rate, this is stored after the uncommon block size or after the coded number in case no uncommon block size was used. See [section uncommon sample rate](#uncommon-sample-rate).
 
 Value   | Sample rate
 :-------|:-----------
@@ -528,23 +528,23 @@ The next bit is reserved and MUST be zero.
 
 ### Coded number
 
-Following the reserved bit (starting at the fifth byte of the frame) is either a sample or a frame number, which will be referred to as the coded number. When dealing with variable blocksize streams, the sample number of the first sample in the frame is encoded. When the file contains a fixed blocksize stream, the frame number is encoded. The coded number is stored in a variable length code like UTF-8, but extended to a maximum of 36 bits unencoded, 7 byte encoded. When a frame number is encoded, the value MUST NOT be larger than what fits a value 31 bits unencoded or 6 byte encoded. Please note that most general purpose UTF-8 encoders and decoders will not be able to handle these extended codes.
+Following the reserved bit (starting at the fifth byte of the frame) is either a sample or a frame number, which will be referred to as the coded number. When dealing with variable block size streams, the sample number of the first sample in the frame is encoded. When the file contains a fixed block size stream, the frame number is encoded. The coded number is stored in a variable length code like UTF-8, but extended to a maximum of 36 bits unencoded, 7 byte encoded. When a frame number is encoded, the value MUST NOT be larger than what fits a value 31 bits unencoded or 6 byte encoded. Please note that most general purpose UTF-8 encoders and decoders will not be able to handle these extended codes.
 
 In case the coded number is a frame number, it MUST be equal to the number of frames preceding the current frame. In case the coded number is a sample number, it MUST be equal to the number of samples preceding the current frame. In a stream where these requirements are not met, seeking is not (reliably) possible.
 
 A decoder that relies on the coded number during seeking could be vulnerable to buffer overflows or getting stuck in an infinite loop in case it seeks in a stream where the coded numbers are non-consecutive or otherwise invalid. See also [the section on security considerations](#security-considerations).
 
-### Uncommon blocksize
+### Uncommon block size
 
-If the blocksize bits defined earlier in this section were 0b0110 or 0b0111 (uncommon blocksize minus 1 stored), this follows the coded number as either an 8-bit or a 16-bit unsigned number coded big-endian.
+If the block size bits defined earlier in this section were 0b0110 or 0b0111 (uncommon block size minus 1 stored), this follows the coded number as either an 8-bit or a 16-bit unsigned number coded big-endian.
 
 ### Uncommon sample rate
 
-Following the uncommon blocksize (or the coded number if no uncommon blocksize is stored) is the sample rate, if the sample rate bits were 0b1100, 0b1101 or 0b1110 (uncommon sample rate stored), as either an 8-bit or a 16-bit unsigned number coded big-endian.
+Following the uncommon block size (or the coded number if no uncommon block size is stored) is the sample rate, if the sample rate bits were 0b1100, 0b1101 or 0b1110 (uncommon sample rate stored), as either an 8-bit or a 16-bit unsigned number coded big-endian.
 
 ### Frame header CRC
 
-Finally, after either the frame/sample number, an uncommon blocksize or an uncommon sample rate, depending on whether the latter two are stored, is an 8-bit CRC. This CRC is initialized with 0 and has the polynomial x^8 + x^2 + x^1 + x^0. This CRC covers the whole frame header before the CRC, including the sync code.
+Finally, after either the frame/sample number, an uncommon block size or an uncommon sample rate, depending on whether the latter two are stored, is an 8-bit CRC. This CRC is initialized with 0 and has the polynomial x^8 + x^2 + x^1 + x^0. This CRC covers the whole frame header before the CRC, including the sync code.
 
 ## Subframes
 
@@ -578,7 +578,7 @@ Besides audio files that have a certain number of wasted bits for the whole file
 In a constant subframe only a single sample is stored. This sample is stored as an integer number coded big-endian, signed two's complement. The number of bits used to store this sample depends on the bit depth of the current subframe. The bit depth of a subframe is equal to the [bit depth as coded in the frame header](#bit-depth-bits), minus the number of [wasted bits coded in the subframe header](#wasted-bits-per-sample). In case a subframe is a side subframe (see the [section on interchannel decorrelation](#interchannel-decorrelation)), the bit depth of that subframe is increased by 1 bit.
 
 ### Verbatim subframe
-A verbatim subframe stores all samples unencoded in sequential order. See [section on Constant subframe](#constant-subframe) on how a sample is stored unencoded. The number of samples that need to be stored in a subframe is given by the blocksize in the frame header.
+A verbatim subframe stores all samples unencoded in sequential order. See [section on Constant subframe](#constant-subframe) on how a sample is stored unencoded. The number of samples that need to be stored in a subframe is given by the block size in the frame header.
 
 ### Fixed predictor subframe
 Five different fixed predictors are defined in the following table, one for each prediction order 0 through 4. In the table is also a derivation, which explains the rationale for choosing these fixed predictors.
@@ -638,9 +638,9 @@ Value       | Description
 
 Both defined coding methods work the same way, but differ in the number of bits used for Rice parameters. The 4 bits that directly follow the coding method bits form the partition order, which is an unsigned number. The rest of the coded residual consists of 2^(partition order) partitions. For example, if the 4 bits are 0b1000, the partition order is 8 and the residual is split up into 2^8 = 256 partitions.
 
-Each partition contains a certain amount of residual samples. The number of residual samples in the first partition is equal to (blocksize >> partition order) - predictor order, i.e. the blocksize divided by the number of partitions minus the predictor order. In all other partitions the number of residual samples is equal to (blocksize >> partition order).
+Each partition contains a certain amount of residual samples. The number of residual samples in the first partition is equal to (block size >> partition order) - predictor order, i.e. the block size divided by the number of partitions minus the predictor order. In all other partitions the number of residual samples is equal to (block size >> partition order).
 
-The partition order MUST be so that the blocksize is evenly divisible by the number of partitions. This means for example that for all odd blocksizes, only partition order 0 is allowed.  The partition order also MUST be so that the (blocksize >> partition order) is larger than the predictor order. This means for example that with a blocksize of 4096 and a predictor order of 4, partition order cannot be larger than 9.
+The partition order MUST be so that the block size is evenly divisible by the number of partitions. This means for example that for all odd block sizes, only partition order 0 is allowed.  The partition order also MUST be so that the (block size >> partition order) is larger than the predictor order. This means for example that with a block size of 4096 and a predictor order of 4, partition order cannot be larger than 9.
 
 In case the coded residual of a subframe is one with a 4-bit Rice parameter (see table at the start of this section), the first 4 bits of each partition are either a Rice parameter or an escape code. These 4 bits indicate an escape code if they are 0b1111, otherwise they contain the Rice parameter as an unsigned number. In case the coded residual of the current subframe is one with a 5-bit Rice parameter, the first 5 bits indicate an escape code if they are 0b11111, otherwise they contain the Rice parameter as an unsigned number as well.
 
@@ -660,7 +660,7 @@ Following the last subframe is the frame footer. If the last subframe is not byt
 
 # Container mappings
 
-The FLAC format can be used without any container as the FLAC format already provides for a very thin transport layer. However, the functionality of this transport is rather limited, and to be able to combine FLAC audio with video, it needs to be encapsulated by a more capable container. This presents a problem: the transport layer provided by the FLAC format mixes data that belongs to the encoded data (like blocksize and sample rate) with data that belongs to the transport (like checksum and timecode). The choice was made to encapsulate FLAC frames as they are, which means some data will be duplicated and potentially deviating between the FLAC frames and the encapsulating container.
+The FLAC format can be used without any container as the FLAC format already provides for a very thin transport layer. However, the functionality of this transport is rather limited, and to be able to combine FLAC audio with video, it needs to be encapsulated by a more capable container. This presents a problem: the transport layer provided by the FLAC format mixes data that belongs to the encoded data (like block size and sample rate) with data that belongs to the transport (like checksum and timecode). The choice was made to encapsulate FLAC frames as they are, which means some data will be duplicated and potentially deviating between the FLAC frames and the encapsulating container.
 
 As FLAC frames are completely independent of each other, container format features handling dependencies do not need to be used. For example, all FLAC frames embedded in Matroska are marked as keyframes when they are stored in a SimpleBlock and tracks in an MP4 file containing only FLAC frames do not need a sync sample box.
 
@@ -701,7 +701,7 @@ In case an audio stream is encoded where audio parameters (sample rate, number o
 
 The full encapsulation definition of FLAC audio in MP4 files was deemed too extensive to include in this document. A definition document can be found at https://github.com/xiph/flac/blob/master/doc/isoflac.txt This document is summarized here.
 
-The sample entry code is 'fLaC'. The channelcount and samplesize fields in the sample entry follow from the values as found in the FLAC stream. The samplerate field can be different, because FLAC can carry audio with much higher samplerates than can be coded for in the sample entry. When possible, the samplerate field should contain the sample rate as found in the FLAC stream, shifted left by 16 bits to get the 16.16 fixed point representation of the samplerate field. When the FLAC stream contains a sample rate higher than can be coded, the samplerate field contains the greatest expressible regular division of the sample rate, e.g. 48000 for sample rates of 96kHz and 192kHz or 44100 for a sample rate of 88200Hz. When the FLAC stream contain audio with an unusual samplerate that has no regular division, the maximum value of 65535.0 Hz is used. As FLAC streams with a high sample rate are common, a parser or decoder MUST read the value from the FLAC streaminfo metadata block or a frame header to determine the actual sample rate. The sample entry contains one 'FLAC specific box' with code 'dfLa'.
+The sample entry code is 'fLaC'. The channelcount and samplesize fields in the sample entry follow from the values as found in the FLAC stream. The samplerate field can be different, because FLAC can carry audio with much higher sample rates than can be coded for in the sample entry. When possible, the samplerate field should contain the sample rate as found in the FLAC stream, shifted left by 16 bits to get the 16.16 fixed point representation of the samplerate field. When the FLAC stream contains a sample rate higher than can be coded, the samplerate field contains the greatest expressible regular division of the sample rate, e.g. 48000 for sample rates of 96kHz and 192kHz or 44100 for a sample rate of 88200Hz. When the FLAC stream contain audio with an unusual sample rate that has no regular division, the maximum value of 65535.0 Hz is used. As FLAC streams with a high sample rate are common, a parser or decoder MUST read the value from the FLAC streaminfo metadata block or a frame header to determine the actual sample rate. The sample entry contains one 'FLAC specific box' with code 'dfLa'.
 
 The FLAC specific box extends FullBox, with version number 0 and all flags set to 0, and contains all FLAC data before the first audio frame but `fLaC` ASCII signature (i.e. all metadata blocks).
 
@@ -725,7 +725,7 @@ Like any other codec (such as [@?RFC6716]), FLAC should not be used with insecur
 
 Implementations of the FLAC codec need to take appropriate security considerations into account. Those related to denial of service are outlined in Section 2.1 of [@!RFC4732]. It is extremely important for the decoder to be robust against malicious payloads. Malicious payloads **MUST NOT** cause the decoder to overrun its allocated memory or to take an excessive amount of resources to decode. An overrun in allocated memory could lead to arbitrary code execution by an attacker. The same applies to the encoder, even though problems in encoders are typically rarer. Malicious audio streams **MUST NOT** cause the encoder to misbehave because this would allow an attacker to attack transcoding gateways.
 
-As with all compression algorithms, both encoding and decoding can produce an output much larger than the input. In case of decoding, the most extreme possible case of this is a frame with eight constant subframes of blocksize 65535 and coding for 32-bit PCM. This frame is only 49 byte in size, but codes for more than 2 megabyte of uncompressed PCM data. For encoding, it is possible to have an even larger size increase, although such behavior is generally considered faulty. This happens if the encoder chooses a rice parameter that does not fit with the residual that has to be encoded. In such a case, very long unary coded symbols can appear, in the most extreme case more than 4 gigabyte per sample. It is RECOMMENDED decoder and encoder implementations take precautions to prevent excessive resource utilization in such cases.
+As with all compression algorithms, both encoding and decoding can produce an output much larger than the input. In case of decoding, the most extreme possible case of this is a frame with eight constant subframes of block size 65535 and coding for 32-bit PCM. This frame is only 49 byte in size, but codes for more than 2 megabyte of uncompressed PCM data. For encoding, it is possible to have an even larger size increase, although such behavior is generally considered faulty. This happens if the encoder chooses a rice parameter that does not fit with the residual that has to be encoded. In such a case, very long unary coded symbols can appear, in the most extreme case more than 4 gigabyte per sample. It is RECOMMENDED decoder and encoder implementations take precautions to prevent excessive resource utilization in such cases.
 
 When metadata is handled, it is RECOMMENDED to either thoroughly test handling of extreme cases or impose reasonable limits beyond the limits of this specification document. For example, a single Vorbis comment metadata block can contain millions of valid fields. It is unlikely such a limit is ever reached except in a potentially malicious file. Likewise the media type and description of a picture metadata block can be millions of characters long, despite there being no reasonable use of such contents. One possible use case for very long character strings is in lyrics, which can be stored in Vorbis comment metadata block fields.
 

--- a/rfc_backmatter.md
+++ b/rfc_backmatter.md
@@ -42,7 +42,7 @@ Where
 
 For subframes with a linear predictor, calculation is a little more complicated. Each prediction is a sum of several multiplications. Each of these multiply a sample value with a predictor coefficient. The extra bits needed can be calculated by adding the predictor coefficient precision (in bits) to the bit depth of the audio samples. As both are signed numbers and only one 'sign bit' is necessary, 1 bit can be subtracted. To account for the summing of these multiplications, the log base 2 of the predictor order rounded up is added.
 
-For example, if the sample bitdepth of the source is 24, the current subframe encodes a side channel (see the [section on interchannel decorrelation](#interchannel-decorrelation)), the predictor order is 12 and the predictor coefficient precision is 15 bits, the minimum required size of the used signed integer data type is at least (24 + 1) + (15 - 1) + ceil(log2(12)) = 43 bits. As another example, with a side-channel subframe bit depth of 16, a predictor order of 8 and a predictor coefficient precision of 12 bits, the minimum required size of the used signed integer data type is (16 + 1) + (12 - 1)  + ceil(log2(8)) = 31 bits.
+For example, if the sample bit depth of the source is 24, the current subframe encodes a side channel (see the [section on interchannel decorrelation](#interchannel-decorrelation)), the predictor order is 12 and the predictor coefficient precision is 15 bits, the minimum required size of the used signed integer data type is at least (24 + 1) + (15 - 1) + ceil(log2(12)) = 43 bits. As another example, with a side-channel subframe bit depth of 16, a predictor order of 8 and a predictor coefficient precision of 12 bits, the minimum required size of the used signed integer data type is (16 + 1) + (12 - 1)  + ceil(log2(8)) = 31 bits.
 
 ## Residual
 
@@ -63,15 +63,15 @@ This informational appendix documents what changes were made to the FLAC format 
 
 The FLAC format was first specified in December 2000 and the bitstream format was considered frozen with the release of FLAC (the reference encoder/decoder) 1.0 in July 2001. Only changes made since this first stable release are considered in this appendix. Changes made to the FLAC subset definition are not considered.
 
-## Addition of blocksize strategy flag
+## Addition of block size strategy flag
 
-Perhaps the largest backwards incompatible change to the specification was published in July 2007. Before this change, variable blocksize streams were not explicitly marked as such by a flag bit in the frame header. A decoder had two ways to detect a variable blocksize stream, either by comparing the minimum and maximum blocksize in the STREAMINFO metadata block (which are equal in case of a fixed blocksize stream), or, in case a decoder did not receive a STREAMINFO metadata block, by detecting a change of blocksize during a stream, which could in theory not happen at all. As the meaning of the coded number in the frame header depends on whether or not a stream is variable blocksize, this presented a problem: the meaning of the coded number could not be reliably determined. To fix this problem, one of the reserved bits was changed to be used as a blocksize strategy flag. [See also the section frame header](#frame-header).
+Perhaps the largest backwards incompatible change to the specification was published in July 2007. Before this change, variable block size streams were not explicitly marked as such by a flag bit in the frame header. A decoder had two ways to detect a variable block size stream, either by comparing the minimum and maximum block size in the STREAMINFO metadata block (which are equal in case of a fixed block size stream), or, in case a decoder did not receive a STREAMINFO metadata block, by detecting a change of block size during a stream, which could in theory not happen at all. As the meaning of the coded number in the frame header depends on whether or not a stream is variable block size, this presented a problem: the meaning of the coded number could not be reliably determined. To fix this problem, one of the reserved bits was changed to be used as a block size strategy flag. [See also the section frame header](#frame-header).
 
-Along with the addition of a new flag, the meaning of the [blocksize bits](#blocksize-bits) was subtly changed. Initially, blocksize bits 0b0001-0b0101 and 0b1000-0b1111 could only be used for fixed blocksize streams, while 0b0110 and 0b0111 could be used for both fixed blocksize and variable blocksize streams. With the change these restrictions were lifted and 0b0001-0b1111 are now used for both variable blocksize and fixed blocksize streams.
+Along with the addition of a new flag, the meaning of the [block size bits](#block-size-bits) was subtly changed. Initially, block size bits 0b0001-0b0101 and 0b1000-0b1111 could only be used for fixed block size streams, while 0b0110 and 0b0111 could be used for both fixed block size and variable block size streams. With the change these restrictions were lifted and 0b0001-0b1111 are now used for both variable block size and fixed block size streams.
 
 ## Restriction of encoded residual samples
 
-Another change to the specification was deemed necessary during standardization by the CELLAR working group of the IETF. As specified in [section coded residual](#coded-residual) a limit is imposed on residual samples. This limit was not specified prior to the IETF standardization effort. However, as far as was known to the working group, no FLAC encoder at that time produced FLAC files containing residual samples exceeding this limit. This is mostly because it is very unlikely to encounter residual samples exceeding this limit when encoding 24-bit PCM, and encoding of PCM with higher bitdepths was not yet implemented in any known encoder. In fact, these FLAC encoders would produce corrupt files upon being triggered to produce such residual samples and it is unlikely any non-experimental encoder would ever do so, even when presented with crafted material. Therefore, it was not expected existing implementation would be rendered non-compliant by this change.
+Another change to the specification was deemed necessary during standardization by the CELLAR working group of the IETF. As specified in [section coded residual](#coded-residual) a limit is imposed on residual samples. This limit was not specified prior to the IETF standardization effort. However, as far as was known to the working group, no FLAC encoder at that time produced FLAC files containing residual samples exceeding this limit. This is mostly because it is very unlikely to encounter residual samples exceeding this limit when encoding 24-bit PCM, and encoding of PCM with higher bit depths was not yet implemented in any known encoder. In fact, these FLAC encoders would produce corrupt files upon being triggered to produce such residual samples and it is unlikely any non-experimental encoder would ever do so, even when presented with crafted material. Therefore, it was not expected existing implementation would be rendered non-compliant by this change.
 
 ## Addition of 5-bit Rice parameter
 
@@ -85,7 +85,7 @@ This appendix provides some considerations for encoder implementations aiming to
 
 ## Variable block size
 
-Because it is often difficult to find the optimal arrangement of block sizes for maximum compression, most encoders choose to create files with a fixed block size. Because of this many decoder implementations suffer from bugs when handling variable block size streams or do not decode them at all. Furthermore, as is explained in [section addition of blocksize strategy flag](#addition-of-blocksize-strategy-flag), there have been some changes to the way variable block size streams were encoded. Because of this, when maximum compatibility with decoders is desired it is RECOMMENDED to only use fixed block size streams.
+Because it is often difficult to find the optimal arrangement of block sizes for maximum compression, most encoders choose to create files with a fixed block size. Because of this many decoder implementations suffer from bugs when handling variable block size streams or do not decode them at all. Furthermore, as is explained in [section addition of block size strategy flag](#addition-of-block-size-strategy-flag), there have been some changes to the way variable block size streams were encoded. Because of this, when maximum compatibility with decoders is desired it is RECOMMENDED to only use fixed block size streams.
 
 ## 5-bit Rice parameter {#rice-parameter-5-bit}
 
@@ -97,7 +97,7 @@ Escapes Rice partitions are only seldom used as it turned out their use provides
 
 ## Uncommon block size
 
-For unknown reasons some decoders have chosen to support only common block sizes except for the last block. Therefore, when maximum compatibility with decoders is desired it is RECOMMENDED to only use common blocksizes as listed in section [bocksize bits](#blocksize-bits) for all but the last block.
+For unknown reasons some decoders have chosen to support only common block sizes except for the last block. Therefore, when maximum compatibility with decoders is desired it is RECOMMENDED to only use common block sizes as listed in section [block size bits](#block-size-bits) for all but the last block.
 
 ## Uncommon bit depth
 
@@ -174,14 +174,14 @@ Start  | Length | Contents        | Description
 0x04+1 | 7 bit  | 0b0000000       | Streaminfo metadata block
 0x05+0 | 3 byte | 0x000022        | Length 34 byte
 
-As the header indicates that this is the last metadata block, the position of the first audio frame can now be calculated as the position of the first byte after the metadata block header + the length of the block, i.e. 8+34 = 42 or 0x2a. As can be seen 0x2a indeed contains the frame sync code for fixed blocksize streams, 0xfff8.
+As the header indicates that this is the last metadata block, the position of the first audio frame can now be calculated as the position of the first byte after the metadata block header + the length of the block, i.e. 8+34 = 42 or 0x2a. As can be seen 0x2a indeed contains the frame sync code for fixed block size streams, 0xfff8.
 
 The streaminfo metadata block contents are broken down in the following table
 
 Start  | Length  | Contents           | Description
 :------|:--------|:-------------------|:-----------------
-0x08+0 | 2 byte  | 0x1000             | Min. blocksize 4096
-0x0a+0 | 2 byte  | 0x1000             | Max. blocksize 4096
+0x08+0 | 2 byte  | 0x1000             | Min. block size 4096
+0x0a+0 | 2 byte  | 0x1000             | Max. block size 4096
 0x0c+0 | 3 byte  | 0x00000f           | Min. frame size 15 byte
 0x0f+0 | 3 byte  | 0x00000f           | Max. frame size 15 byte
 0x12+0 | 20 bit  | 0x0ac4, 0b0100     | Sample rate 44100 Hertz
@@ -190,9 +190,9 @@ Start  | Length  | Contents           | Description
 0x15+4 | 36 bit  | 0b0000, 0x00000001 | Total no. of samples 1
 0x1a   | 16 byte | (...)              | MD5 signature
 
-The minimum and maximum blocksize are both 4096. This was apparently the blocksize the encoder planned to use, but as only 1 interchannel sample was provided, no frames with 4096 samples are actually present in this file.
+The minimum and maximum block size are both 4096. This was apparently the block size the encoder planned to use, but as only 1 interchannel sample was provided, no frames with 4096 samples are actually present in this file.
 
-Note that anywhere a number of samples is mentioned (blocksize, total number of samples, sample rate), interchannel samples are meant.
+Note that anywhere a number of samples is mentioned (block size, total number of samples, sample rate), interchannel samples are meant.
 
 The MD5 sum (starting at 0x1a) is 0x3e84 b418 07dc 6903 0758 6a3d ad1a 2e0f. This will be validated after decoding the samples.
 
@@ -203,17 +203,17 @@ The frame header starts at position 0x2a and is broken down in the following tab
 Start  | Length | Contents        | Description
 :------|:-------|:----------------|:-----------------
 0x2a+0 | 15 bit | 0xff, 0b1111100 | frame sync
-0x2b+7 | 1 bit  | 0b0             | blocksize strategy
-0x2c+0 | 4 bit  | 0b0110          | 8-bit blocksize further down
+0x2b+7 | 1 bit  | 0b0             | block size strategy
+0x2c+0 | 4 bit  | 0b0110          | 8-bit block size further down
 0x2c+4 | 4 bit  | 0b1001          | sample rate 44.1kHz
 0x2d+0 | 4 bit  | 0b0001          | stereo, no decorrelation
 0x2d+4 | 3 bit  | 0b100           | bit depth 16 bit
 0x2d+7 | 1 bit  | 0b0             | mandatory 0 bit
 0x2e+0 | 1 byte | 0x00            | frame number 0
-0x2f+0 | 1 byte | 0x00            | blocksize 1
+0x2f+0 | 1 byte | 0x00            | block size 1
 0x30+0 | 1 byte | 0xbf            | frame header CRC
 
-As the stream is a fixed blocksize stream, the number at 0x2e contains a frame number. As the value is smaller than 128, only 1 byte is used for the encoding.
+As the stream is a fixed block size stream, the number at 0x2e contains a frame number. As the value is smaller than 128, only 1 byte is used for the encoding.
 
 At byte 0x31 the subframe header of the first subframe starts, it is broken down in the following table.
 
@@ -228,7 +228,7 @@ Start  | Length | Contents        | Description
 
 As the wasted bits flag is 1 in this subframe, an unary coded number follows. Starting at 0x32, we see 0b01, which unary codes for 1, meaning we have 2 wasted bits in this subframe.
 
-As this is a verbatim subframe, the subframe only contains unencoded sample values. With a blocksize of 1, it contains only a single sample. The bit depth of the audio is 16 bit, but as the subframe header signals 2 wasted bits, only 14 bits are stored. As no stereo decorrelation is used, a bit depth increase for the side channel is not applicable. So, the next 14 bit (starting at position 0x32+2) contain the unencoded sample coded big-endian, signed two's complement. The value reads 0b011000 11111101, or 6397. This value needs to be shifted left by 2 bits, to account for the wasted bits. The value is then 0b011000 11111101 00, or 25588.
+As this is a verbatim subframe, the subframe only contains unencoded sample values. With a block size of 1, it contains only a single sample. The bit depth of the audio is 16 bit, but as the subframe header signals 2 wasted bits, only 14 bits are stored. As no stereo decorrelation is used, a bit depth increase for the side channel is not applicable. So, the next 14 bit (starting at position 0x32+2) contain the unencoded sample coded big-endian, signed two's complement. The value reads 0b011000 11111101, or 6397. This value needs to be shifted left by 2 bits, to account for the wasted bits. The value is then 0b011000 11111101 00, or 25588.
 
 The second subframe starts at 0x34, it is broken down in the following table.
 
@@ -311,14 +311,14 @@ Most of the streaminfo block, including its header, is the same as in example 1,
 Start  | Length  | Contents           | Description
 :------|:--------|:-------------------|:-----------------
 0x04+0 | 1 bit   | 0b0                | Not the last metadata block
-0x08+0 | 2 byte  | 0x0010             | Min. blocksize 16
-0x0a+0 | 2 byte  | 0x0010             | Max. blocksize 16
+0x08+0 | 2 byte  | 0x0010             | Min. block size 16
+0x0a+0 | 2 byte  | 0x0010             | Max. block size 16
 0x0c+0 | 3 byte  | 0x000017           | Min. frame size 23 byte
 0x0f+0 | 3 byte  | 0x000044           | Max. frame size 68 byte
 0x15+4 | 36 bit  | 0b0000, 0x00000013 | Total no. of samples 19
 0x1a   | 16 byte | (...)              | MD5 signature
 
-This time, the minimum and maximum blocksizes are reflected in the file: there is one block of 16 samples, the last block (which has 3 samples) is not considered for the minimum blocksize. The MD5 signature is 0xd5b0 5649 75e9 8b8d 8b93 0422 757b 8103, this will be verified at the end of this example.
+This time, the minimum and maximum block sizes are reflected in the file: there is one block of 16 samples, the last block (which has 3 samples) is not considered for the minimum block size. The MD5 signature is 0xd5b0 5649 75e9 8b8d 8b93 0422 757b 8103, this will be verified at the end of this example.
 
 ### Seektable
 
@@ -331,7 +331,7 @@ Start  | Length  | Contents           | Description
 0x2b+0 | 3 byte  | 0x000012           | Length 18 byte
 0x2e+0 | 8 byte  | 0x0000000000000000 | Seekpoint to sample 0
 0x36+0 | 8 byte  | 0x0000000000000000 | Seekpoint to offset 0
-0x3e+0 | 2 byte  | 0x0010             | Seekpoint to blocksize 16
+0x3e+0 | 2 byte  | 0x0010             | Seekpoint to block size 16
 
 ### Vorbis comment
 
@@ -368,14 +368,14 @@ The frame header starts at position 0x88 and is broken down in the following tab
 Start  | Length | Contents        | Description
 :------|:-------|:----------------|:-----------------
 0x88+0 | 15 bit | 0xff, 0b1111100 | frame sync
-0x89+7 | 1 bit  | 0b0             | blocksize strategy
-0x8a+0 | 4 bit  | 0b0110          | 8-bit blocksize further down
+0x89+7 | 1 bit  | 0b0             | block size strategy
+0x8a+0 | 4 bit  | 0b0110          | 8-bit block size further down
 0x8a+4 | 4 bit  | 0b1001          | sample rate 44.1kHz
 0x8b+0 | 4 bit  | 0b1001          | right-side stereo
 0x8b+4 | 3 bit  | 0b100           | bit depth 16 bit
 0x8b+7 | 1 bit  | 0b0             | mandatory 0 bit
 0x8c+0 | 1 byte | 0x00            | frame number 0
-0x8d+0 | 1 byte | 0x0f            | blocksize 16
+0x8d+0 | 1 byte | 0x0f            | block size 16
 0x8e+0 | 1 byte | 0x99            | frame header CRC
 
 The first subframe starts at byte 0x8f, it is broken down in the following table excluding the coded residual. As this subframe codes for a side channel, the bit depth is increased by 1 bit from 16 bit to 17 bit. This is most clearly present in the unencoded warm-up sample.
@@ -500,14 +500,14 @@ The frame header starts at position 0xcc and is broken down in the following tab
 Start  | Length | Contents        | Description
 :------|:-------|:----------------|:-----------------
 0xcc+0 | 15 bit | 0xff, 0b1111100 | frame sync
-0xcd+7 | 1 bit  | 0b0             | blocksize strategy
-0xce+0 | 4 bit  | 0b0110          | 8-bit blocksize further down
+0xcd+7 | 1 bit  | 0b0             | block size strategy
+0xce+0 | 4 bit  | 0b0110          | 8-bit block size further down
 0xce+4 | 4 bit  | 0b1001          | sample rate 44.1kHz
 0xcf+0 | 4 bit  | 0b0001          | stereo, no decorrelation
 0xcf+4 | 3 bit  | 0b100           | bit depth 16 bit
 0xcf+7 | 1 bit  | 0b0             | mandatory 0 bit
 0xd0+0 | 1 byte | 0x01            | frame number 1
-0xd1+0 | 1 byte | 0x02            | blocksize 3
+0xd1+0 | 1 byte | 0x02            | block size 3
 0xd2+0 | 1 byte | 0xa4            | frame header CRC
 
 The first subframe starts at 0xd3+0 and is broken down in the following table.
@@ -602,14 +602,14 @@ The frame header starts at position 0x2a and is broken down in the following tab
 Start  | Length | Contents        | Description
 :------|:-------|:----------------|:-----------------
 0x2a+0 | 15 bit | 0xff, 0b1111100 | Frame sync
-0x2b+7 | 1 bit  | 0b0             | Blocksize strategy
-0x2c+0 | 4 bit  | 0b0110          | 8-bit blocksize further down
+0x2b+7 | 1 bit  | 0b0             | Block size strategy
+0x2c+0 | 4 bit  | 0b0110          | 8-bit block size further down
 0x2c+4 | 4 bit  | 0b1000          | Sample rate 32kHz
 0x2d+0 | 4 bit  | 0b0000          | Mono audio (1 channel)
 0x2d+4 | 3 bit  | 0b001           | Bit depth 8 bit
 0x2d+7 | 1 bit  | 0b0             | Mandatory 0 bit
 0x2e+0 | 1 byte | 0x00            | Frame number 0
-0x2f+0 | 1 byte | 0x17            | Blocksize 24
+0x2f+0 | 1 byte | 0x17            | Block size 24
 0x30+0 | 1 byte | 0xe9            | Frame header CRC
 
 The first and only subframe starts at byte 0x31, it is broken down in the following table, without the coded residual.


### PR DESCRIPTION
This fixes https://github.com/ietf-wg-cellar/flac-specification/issues/139

The bit for the MP4 mapping might be tricky. Apparently MP4 sample entries have a samplerate field. So in this text samplerate refers to the MP4 field and sample rate is used when not talking about that field specifically. I don't know whether that is the best way to do this.