### PR TITLE
Hertz -> hertz

### DIFF
--- a/flac.md
+++ b/flac.md
@@ -1,6 +1,6 @@
 # Introduction
 
-This document defines the FLAC format. FLAC files and streams can code for pulse-code modulated (PCM) audio with 1 to 8 channels, sample rates from 1 to 1048576 Hertz and bit depths between 4 and 32 bits. Most tools for coding to and decoding from the FLAC format have been optimized for CD-audio, which is PCM audio with 2 channels, a sample rate of 44.1 kHz and a bit depth of 16 bits.
+This document defines the FLAC format. FLAC files and streams can code for pulse-code modulated (PCM) audio with 1 to 8 channels, sample rates from 1 to 1048576 hertz and bit depths between 4 and 32 bits. Most tools for coding to and decoding from the FLAC format have been optimized for CD-audio, which is PCM audio with 2 channels, a sample rate of 44.1 kHz and a bit depth of 16 bits.
 
 FLAC is able to achieve lossless compression because samples in audio signals tend to be highly correlated with their close neighbors. In contrast with general purpose compressors, which often use dictionaries, do run-length coding or exploit long-term repetition, FLAC removes redundancy solely in the very short term, looking back at most 32 samples.
 

--- a/rfc_backmatter.md
+++ b/rfc_backmatter.md
@@ -184,7 +184,7 @@ Start  | Length  | Contents           | Description
 0x0a+0 | 2 byte  | 0x1000             | Max. blocksize 4096
 0x0c+0 | 3 byte  | 0x00000f           | Min. frame size 15 byte
 0x0f+0 | 3 byte  | 0x00000f           | Max. frame size 15 byte
-0x12+0 | 20 bit  | 0x0ac4, 0b0100     | Sample rate 44100 Hertz
+0x12+0 | 20 bit  | 0x0ac4, 0b0100     | Sample rate 44100 hertz
 0x14+4 | 3 bit   | 0b001              | 2 channels
 0x14+7 | 5 bit   | 0b01111            | Sample bit depth 16
 0x15+4 | 36 bit  | 0b0000, 0x00000001 | Total no. of samples 1
@@ -588,7 +588,7 @@ Start  | Length  | Contents           | Description
 :------|:--------|:-------------------|:-----------------
 0x0c+0 | 3 byte  | 0x00001f           | Min. frame size 31 byte
 0x0f+0 | 3 byte  | 0x00001f           | Max. frame size 31 byte
-0x12+0 | 20 bit  | 0x07d0, 0x0000     | Sample rate 32000 Hertz
+0x12+0 | 20 bit  | 0x07d0, 0x0000     | Sample rate 32000 hertz
 0x14+4 | 3 bit   | 0b000              | 1 channel
 0x14+7 | 5 bit   | 0b00111            | Sample bit depth 8 bit
 0x15+4 | 36 bit  | 0b0000, 0x00000018 | Total no. of samples 24


### PR DESCRIPTION
SI units should not be capitalized, not even when person names are used. Suggested at https://hydrogenaud.io/index.php/topic,123069.0.html