### PR TITLE
Clarify data type width of addition residual and prediction

### DIFF
--- a/rfc_backmatter.md
+++ b/rfc_backmatter.md
@@ -54,6 +54,8 @@ Taking the last example of the previous section, where 31 bits were needed for t
 
 As another example, when encoding 32-bit PCM with fixed predictors, all predictor orders must be checked. While the 0-order fixed predictor is guaranteed to have residuals that fit a 32-bit signed int, it might produce a residual being the most negative representable value of that 32-bit signed int.
 
+Note that on decoding, while the residual samples are limited to the aforementioned range, the predictions are not. This means that while the decoding of the residual samples can happen fully in 32-bit signed integers, decoders must be sure to execute the addition of each residual sample to its accompanying prediction with a wide enough signed integer data type like on encoding.
+
 ## Rice coding
 When folding (i.e. zig-zag encoding) the residual sample values, no extra bits are needed when the absolute value of each residual sample is first stored in an unsigned data type of the size of the last step, then doubled and then has one subtracted depending on whether the residual sample was positive or negative. Many implementations however choose to require one extra bit of data type size so zig-zag encoding can happen in one step and without a cast instead of the procedure described in the previous sentence.
 


### PR DESCRIPTION
I got a question about this recently, so it seemed fitting to add a note.